### PR TITLE
Fix Macbook → MacBook capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # darwin-vm
 
 Run iOS/ macOS in Qemu. Supports emulating iPhone 17, 16, 15, 14, 13, and 12
-(A19-A14) and M5-M1 Macs (tested with Macbook Air and Mac Mini). You can debug
+(A19-A14) and M5-M1 Macs (tested with MacBook Air and Mac Mini). You can debug
 the kernel, edit the root filesystem, and run a root shell + custom programs.
 
 Features:


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 4).

## Problem

'Macbook' is the wrong capitalization of the Apple brand name 'MacBook'.

The problematic text:

```markdown
(test with Macbook Air and Mac Mini)
```

## Fix

Replaced with:

```markdown
(test with MacBook Air and Mac Mini)
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text