### PR TITLE
Fix missing hyphen: SPTM based → SPTM-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Features:
 - Compile and run your own programs as root in the VM, no jailbreak or kernel patches required.
 - Runs anywhere qemu runs (ARM host not required).
 - Supports emulating A19-A14 (iOS) and M5-M1 (macOS) CPUs.
-- Supports SPTM based kernels and CPUs with MIE.
+- Supports SPTM-based kernels and CPUs with MIE.
 - Can debug / patch the kernel, SPTM, TXM, dyld, launchd, and userspace programs.
 - Automated setup to get going in just a few minutes.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 13).

## Problem

Compound modifier 'SPTM based' is missing a hyphen.

The problematic text:

```markdown
Supports SPTM based kernels and CPUs with MIE.
```

## Fix

Replaced with:

```markdown
Supports SPTM-based kernels and CPUs with MIE.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text